### PR TITLE
fix stylesheet querySelector (by quoting)

### DIFF
--- a/src/lib/hooks/useGlobalStyles.ts
+++ b/src/lib/hooks/useGlobalStyles.ts
@@ -18,7 +18,7 @@ function useGlobalStyles(duration: number, hideScrollbars: boolean) {
     document.head.appendChild(tag);
 
     return function() {
-      const stylesheet = document.querySelector(`style[data-react-bottom-drawer=${identifier}]`);
+      const stylesheet = document.querySelector(`style[data-react-bottom-drawer='${identifier}']`);
       if (stylesheet) { stylesheet.remove(); }
     }
   }, [duration, hideScrollbars]);


### PR DESCRIPTION
Wrap selector in quotes to avoid error on select.