### PR TITLE
Fix error running in strictMode due to findDOMNode internal usage in Transition

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
     "rimraf": "^3.0.2",
-    "typescript": "^3.8.3"
+    "typescript": "4.0.2"
   },
   "dependencies": {
     "body-scroll-lock": "^3.0.1",

--- a/src/demo.tsx
+++ b/src/demo.tsx
@@ -8,34 +8,36 @@ function Demo() {
   
   return (
     <>
-      <button onClick={() => setIsOpen(true)}>Open Drawer</button>
-      <Drawer
-        isVisible={isOpen}
-        onClose={() => setIsOpen(false)}
-        duration={250}
-        hideScrollbars={true}
-      >
-        <h1> React Bottom Drawers! </h1>
-        <p>
-          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque commodo vitae sapien in gravida. Donec fermentum nibh interdum, laoreet arcu sit amet, condimentum enim. Duis justo est, commodo vel ultricies ut, consequat vel velit. Aliquam erat volutpat. Integer vel erat ut ipsum interdum ornare. Vivamus vitae quam cursus, varius lorem ut, aliquet eros. Aenean rhoncus nisl sit amet lorem dapibus, eu placerat odio tempus. Ut justo ipsum, tempor quis rutrum nec, aliquam et nunc. Donec nec nisi nec ligula vehicula venenatis eu nec lorem. Aliquam nec sagittis lectus. Quisque sapien ligula, elementum non rutrum et, laoreet ut lectus. In a elit id tortor volutpat tempus eget vitae tellus. Vivamus iaculis odio tellus, id egestas velit consectetur nec. Phasellus molestie elit in lacinia aliquam.
-        </p>
-        
-        <p>
-          In vel semper nisl. Praesent felis augue, hendrerit ac scelerisque vel, bibendum ut turpis. Aliquam volutpat purus massa, vitae consequat arcu lacinia at. Suspendisse vitae mattis turpis. Donec sit amet rutrum est, eu posuere nibh. Vivamus imperdiet sed est in aliquet. Aenean libero massa, consequat nec convallis sed, iaculis nec quam. Maecenas vel rutrum lorem. Nullam eu hendrerit odio, quis consequat odio. Donec fringilla mi dignissim quam eleifend mattis. Sed ligula nibh, tincidunt nec dictum ultricies, rutrum at dui. Sed hendrerit nulla sit amet leo facilisis interdum. Aenean sagittis at ex id auctor. Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Sed sed metus id urna ultrices imperdiet sed id enim. Suspendisse rhoncus ex lorem, et commodo turpis sollicitudin blandit.
-        </p>
+      <React.StrictMode>
+        <button onClick={() => setIsOpen(true)}>Open Drawer</button>
+        <Drawer
+          isVisible={isOpen}
+          onClose={() => setIsOpen(false)}
+          duration={250}
+          hideScrollbars={true}
+        >
+          <h1> React Bottom Drawers! </h1>
+          <p>
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque commodo vitae sapien in gravida. Donec fermentum nibh interdum, laoreet arcu sit amet, condimentum enim. Duis justo est, commodo vel ultricies ut, consequat vel velit. Aliquam erat volutpat. Integer vel erat ut ipsum interdum ornare. Vivamus vitae quam cursus, varius lorem ut, aliquet eros. Aenean rhoncus nisl sit amet lorem dapibus, eu placerat odio tempus. Ut justo ipsum, tempor quis rutrum nec, aliquam et nunc. Donec nec nisi nec ligula vehicula venenatis eu nec lorem. Aliquam nec sagittis lectus. Quisque sapien ligula, elementum non rutrum et, laoreet ut lectus. In a elit id tortor volutpat tempus eget vitae tellus. Vivamus iaculis odio tellus, id egestas velit consectetur nec. Phasellus molestie elit in lacinia aliquam.
+          </p>
+          
+          <p>
+            In vel semper nisl. Praesent felis augue, hendrerit ac scelerisque vel, bibendum ut turpis. Aliquam volutpat purus massa, vitae consequat arcu lacinia at. Suspendisse vitae mattis turpis. Donec sit amet rutrum est, eu posuere nibh. Vivamus imperdiet sed est in aliquet. Aenean libero massa, consequat nec convallis sed, iaculis nec quam. Maecenas vel rutrum lorem. Nullam eu hendrerit odio, quis consequat odio. Donec fringilla mi dignissim quam eleifend mattis. Sed ligula nibh, tincidunt nec dictum ultricies, rutrum at dui. Sed hendrerit nulla sit amet leo facilisis interdum. Aenean sagittis at ex id auctor. Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Sed sed metus id urna ultrices imperdiet sed id enim. Suspendisse rhoncus ex lorem, et commodo turpis sollicitudin blandit.
+          </p>
 
-        <p>
-          Morbi eu ullamcorper sapien. Aenean vitae vestibulum orci. Sed in volutpat urna. Aliquam erat volutpat. Pellentesque aliquet sit amet massa ut tempor. Aenean sit amet magna efficitur, sollicitudin tellus tincidunt, blandit lectus. Aliquam in nulla et metus bibendum euismod non et dui. Integer posuere porta ligula, et iaculis lectus lacinia vitae. Aliquam erat volutpat.
-        </p>
+          <p>
+            Morbi eu ullamcorper sapien. Aenean vitae vestibulum orci. Sed in volutpat urna. Aliquam erat volutpat. Pellentesque aliquet sit amet massa ut tempor. Aenean sit amet magna efficitur, sollicitudin tellus tincidunt, blandit lectus. Aliquam in nulla et metus bibendum euismod non et dui. Integer posuere porta ligula, et iaculis lectus lacinia vitae. Aliquam erat volutpat.
+          </p>
 
-        <p>
-          Integer faucibus, leo sit amet facilisis tempus, dolor enim porttitor lorem, sit amet facilisis dui neque in mi. Morbi nisl metus, cursus quis quam id, tristique ullamcorper sem. Morbi vitae posuere massa, in tristique quam. Phasellus id laoreet nulla, vel ullamcorper ante. Cras nec augue sed metus tincidunt fringilla non eu turpis. In quis est tellus. Vestibulum eget fringilla lorem, porttitor faucibus neque. Nam congue, libero id pulvinar hendrerit, mi eros malesuada nibh, a euismod eros enim et magna. Etiam nec placerat nunc. Integer porttitor mauris ut mi vehicula, lobortis pulvinar leo scelerisque. Suspendisse maximus lorem nec ornare tincidunt.
-        </p>
+          <p>
+            Integer faucibus, leo sit amet facilisis tempus, dolor enim porttitor lorem, sit amet facilisis dui neque in mi. Morbi nisl metus, cursus quis quam id, tristique ullamcorper sem. Morbi vitae posuere massa, in tristique quam. Phasellus id laoreet nulla, vel ullamcorper ante. Cras nec augue sed metus tincidunt fringilla non eu turpis. In quis est tellus. Vestibulum eget fringilla lorem, porttitor faucibus neque. Nam congue, libero id pulvinar hendrerit, mi eros malesuada nibh, a euismod eros enim et magna. Etiam nec placerat nunc. Integer porttitor mauris ut mi vehicula, lobortis pulvinar leo scelerisque. Suspendisse maximus lorem nec ornare tincidunt.
+          </p>
 
-        <p>
-          Sed interdum vitae ante nec consectetur. Quisque elementum tortor erat, condimentum gravida massa commodo non. Maecenas eget ante vel purus suscipit volutpat. Nulla vulputate euismod urna sit amet tristique. Morbi rhoncus urna et erat varius, non bibendum tortor fermentum. Proin finibus ligula quis ipsum tempus laoreet. Aenean ipsum neque, mollis et tortor in, lobortis hendrerit est. In sed commodo nunc.
-        </p>
-      </Drawer>      
+          <p>
+            Sed interdum vitae ante nec consectetur. Quisque elementum tortor erat, condimentum gravida massa commodo non. Maecenas eget ante vel purus suscipit volutpat. Nulla vulputate euismod urna sit amet tristique. Morbi rhoncus urna et erat varius, non bibendum tortor fermentum. Proin finibus ligula quis ipsum tempus laoreet. Aenean ipsum neque, mollis et tortor in, lobortis hendrerit est. In sed commodo nunc.
+          </p>
+        </Drawer>      
+      </React.StrictMode>
     </>
   )
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -30,6 +30,7 @@ const SlideUpTransition = ({
   hideScrollbars = false,
 }: IProps) => {
   const classNames = useGlobalStyles(duration, hideScrollbars);
+  const nodeRef = React.useRef(null);
   
   // Actions to close
   useEscButton(onClose, isVisible);
@@ -73,9 +74,10 @@ const SlideUpTransition = ({
         timeout={{ appear: 0, enter: 0, exit: duration }}
         unmountOnExit={unmountOnExit}
         mountOnEnter={mountOnEnter}
+        nodeRef={nodeRef}
       >
         {(state) => (
-          <>
+          <div ref={nodeRef}>
             <div onClick={onClose} className={classNames.backdrop} style={BackdropStyles[state]} />
             <div
             className={classNames.drawer}
@@ -89,7 +91,7 @@ const SlideUpTransition = ({
               </div>
               <div className={classNames.contentWrapper}>{children}</div>
             </div>
-          </>
+          </div>
         )}
       </Transition>
     </>

--- a/src/lib/hooks/useGlobalStyles.ts
+++ b/src/lib/hooks/useGlobalStyles.ts
@@ -18,7 +18,7 @@ function useGlobalStyles(duration: number, hideScrollbars: boolean) {
     document.head.appendChild(tag);
 
     return function() {
-      const stylesheet = document.querySelector(`style[data-react-bottom-drawer=${identifier}]`);
+      const stylesheet = document.querySelector(`style[data-react-bottom-drawer='${identifier}']`);
       if (stylesheet) { stylesheet.remove(); }
     }
   }, [duration, hideScrollbars]);

--- a/yarn.lock
+++ b/yarn.lock
@@ -751,10 +751,17 @@
     "@babel/types" "^7.4.4"
     esutils "^2.0.2"
 
-"@babel/runtime@^7.4.4", "@babel/runtime@^7.5.5", "@babel/runtime@^7.8.4", "@babel/runtime@^7.8.7":
+"@babel/runtime@^7.4.4", "@babel/runtime@^7.8.4":
   version "7.9.2"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.9.2.tgz#d90df0583a3a252f09aaa619665367bae518db06"
   integrity sha512-NE2DtOdufG7R5vnfQUTehdTfNycfUANEtCa9PssN9O/xmTzP4E08UI797ixaei6hBEVL9BI/PsdJS5x7mWoB9Q==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
+"@babel/runtime@^7.5.5", "@babel/runtime@^7.8.7":
+  version "7.11.2"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.11.2.tgz#f549c13c754cc40b87644b9fa9f09a6a95fe0736"
+  integrity sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==
   dependencies:
     regenerator-runtime "^0.13.4"
 
@@ -878,9 +885,9 @@
   integrity sha512-ce5d3q03Ex0sy4R14722Rmt6MT07Ua+k4FwDfdcToYJcMKNtRVQvJ6JCAPdAmAnbRb6CsX6aYb9m96NGod9uTw==
 
 "@types/react-dom@^16.9.6":
-  version "16.9.6"
-  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-16.9.6.tgz#9e7f83d90566521cc2083be2277c6712dcaf754c"
-  integrity sha512-S6ihtlPMDotrlCJE9ST1fRmYrQNNwfgL61UB4I1W7M6kPulUKx9fXAleW5zpdIjUQ4fTaaog8uERezjsGUj9HQ==
+  version "16.9.8"
+  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-16.9.8.tgz#fe4c1e11dfc67155733dfa6aa65108b4971cb423"
+  integrity sha512-ykkPQ+5nFknnlU6lDd947WbQ6TE3NNzbQAkInC2EKY1qeYdTKp7onFusmYZb+ityzx2YviqT6BXSu+LyWWJwcA==
   dependencies:
     "@types/react" "*"
 
@@ -892,19 +899,19 @@
     react-swipeable "*"
 
 "@types/react-transition-group@^4.2.4":
-  version "4.2.4"
-  resolved "https://registry.yarnpkg.com/@types/react-transition-group/-/react-transition-group-4.2.4.tgz#c7416225987ccdb719262766c1483da8f826838d"
-  integrity sha512-8DMUaDqh0S70TjkqU0DxOu80tFUiiaS9rxkWip/nb7gtvAsbqOXm02UCmR8zdcjWujgeYPiPNTVpVpKzUDotwA==
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/@types/react-transition-group/-/react-transition-group-4.4.0.tgz#882839db465df1320e4753e6e9f70ca7e9b4d46d"
+  integrity sha512-/QfLHGpu+2fQOqQaXh8MG9q03bFENooTb/it4jr5kKaZlDQfWvjqWZg48AwzPVMBHlRuTRAY7hRHCEOXz5kV6w==
   dependencies:
     "@types/react" "*"
 
 "@types/react@*", "@types/react@^16.9.32":
-  version "16.9.32"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.9.32.tgz#f6368625b224604148d1ddf5920e4fefbd98d383"
-  integrity sha512-fmejdp0CTH00mOJmxUPPbWCEBWPvRIL4m8r0qD+BSDUqmutPyGQCHifzMpMzdvZwROdEdL78IuZItntFWgPXHQ==
+  version "16.9.47"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.9.47.tgz#fb092936f0b56425f874d0ff1b08051fdf70c1ba"
+  integrity sha512-dAJO4VbrjYqTUwFiQqAKjLyHHl4RSTNnRyPdX3p16MPbDKvow51wxATUPxoe2QsiXNMEYrOjc2S6s92VjG+1VQ==
   dependencies:
     "@types/prop-types" "*"
-    csstype "^2.2.0"
+    csstype "^3.0.2"
 
 abab@^2.0.0:
   version "2.0.3"
@@ -1169,9 +1176,9 @@ bn.js@^4.0.0, bn.js@^4.1.0, bn.js@^4.1.1, bn.js@^4.4.0:
   integrity sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==
 
 body-scroll-lock@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/body-scroll-lock/-/body-scroll-lock-3.0.1.tgz#bacb9ebf64fef2498392a3b779f4943af2004fad"
-  integrity sha512-BYcnBAv6r3iKFDeYgG3ZMiOtxHDcHaev84he4vU4nB062A9MSUHsbVkrgsiSZlGCcWqoqGKCKTytSUhzuEjiCQ==
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/body-scroll-lock/-/body-scroll-lock-3.0.3.tgz#221d87435bcfb50e27ab5d4508735f622aed11a2"
+  integrity sha512-EUryImgD6Gv87HOjJB/yB2WIGECiZMhmcUK+DrqVRFDDa64xR+FsK0LgvLPnBxZDTxIl+W80/KJ8i6gp2IwOHQ==
 
 boolbase@^1.0.0, boolbase@~1.0.0:
   version "1.0.0"
@@ -1830,10 +1837,10 @@ cssstyle@^1.1.1:
   dependencies:
     cssom "0.3.x"
 
-csstype@^2.2.0, csstype@^2.6.7:
-  version "2.6.10"
-  resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.6.10.tgz#e63af50e66d7c266edb6b32909cfd0aabe03928b"
-  integrity sha512-D34BqZU4cIlMCY93rZHbrq9pjTAQJ3U8S8rfBqjwHxkGPThWFjzZDQpgMJY0QViLxth6ZKYiwFBo14RdN44U/w==
+csstype@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.0.2.tgz#ee5ff8f208c8cd613b389f7b222c9801ca62b3f7"
+  integrity sha512-ofovWglpqoqbfLNOTBNZLSbMuGrblAf1efvvArGKOZMBrIoJeu5UsAipQolkijtyQx5MtAzT/J9IHj/CEY1mJw==
 
 dashdash@^1.12.0:
   version "1.14.1"
@@ -1957,12 +1964,12 @@ diffie-hellman@^5.0.0:
     randombytes "^2.0.0"
 
 dom-helpers@^5.0.1:
-  version "5.1.4"
-  resolved "https://registry.yarnpkg.com/dom-helpers/-/dom-helpers-5.1.4.tgz#4609680ab5c79a45f2531441f1949b79d6587f4b"
-  integrity sha512-TjMyeVUvNEnOnhzs6uAn9Ya47GmMo3qq7m+Lr/3ON0Rs5kHvb8I+SQYjLUSYn7qhEm0QjW0yrBkvz9yOrwwz1A==
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/dom-helpers/-/dom-helpers-5.2.0.tgz#57fd054c5f8f34c52a3eeffdb7e7e93cd357d95b"
+  integrity sha512-Ru5o9+V8CpunKnz5LGgWXkmrH/20cGKwcHwS4m73zIvs54CN9epEmT/HLqFJW3kXpakAFkEdzgy1hzlJe3E4OQ==
   dependencies:
     "@babel/runtime" "^7.8.7"
-    csstype "^2.6.7"
+    csstype "^3.0.2"
 
 dom-serializer@0:
   version "0.2.2"
@@ -4254,9 +4261,9 @@ react-swipeable@*, react-swipeable@^5.5.1:
     prop-types "^15.6.2"
 
 react-transition-group@^4.3.0:
-  version "4.3.0"
-  resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-4.3.0.tgz#fea832e386cf8796c58b61874a3319704f5ce683"
-  integrity sha512-1qRV1ZuVSdxPlPf4O8t7inxUGpdyO5zG9IoNfJxSO0ImU2A1YWkEQvFPuIPZmMLkg5hYs7vv5mMOyfgSkvAwvw==
+  version "4.4.1"
+  resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-4.4.1.tgz#63868f9325a38ea5ee9535d828327f85773345c9"
+  integrity sha512-Djqr7OQ2aPUiYurhPalTrVy9ddmFCCzwhqQmtN+J3+3DzLO209Fdr70QrN8Z3DsglWql6iY1lDWAfpFiBtuKGw==
   dependencies:
     "@babel/runtime" "^7.5.5"
     dom-helpers "^5.0.1"
@@ -4321,9 +4328,9 @@ regenerator-runtime@^0.11.0:
   integrity sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==
 
 regenerator-runtime@^0.13.4:
-  version "0.13.5"
-  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz#d878a1d094b4306d10b9096484b33ebd55e26697"
-  integrity sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA==
+  version "0.13.7"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz#cac2dacc8a1ea675feaabaeb8ae833898ae46f55"
+  integrity sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew==
 
 regenerator-transform@^0.14.2:
   version "0.14.4"
@@ -5071,10 +5078,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@^3.8.3:
-  version "3.8.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.8.3.tgz#409eb8544ea0335711205869ec458ab109ee1061"
-  integrity sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==
+typescript@4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.0.2.tgz#7ea7c88777c723c681e33bf7988be5d008d05ac2"
+  integrity sha512-e4ERvRV2wb+rRZ/IQeb3jm2VxBsirQLpQhdxplZ2MEzGvDkkMmPglecnNDfSUBivMjP93vRbngYYDQqQ/78bcQ==
 
 uncss@^0.17.2:
   version "0.17.3"


### PR DESCRIPTION
add nodeRef alternative instead of internal findDOMNode
react-transition-group internally uses findDOMNode, which is deprecated and produces warnings in Strict Mode, so now you can optionally pass nodeRef to Transition and CSSTransition, it's a ref object that should point to the transitioning child:
See https://github.com/reactjs/react-transition-group/compare/v4.3.0...v4.4.0 for details.

* bump typescript to latest. 
* Make demo run in strictMode
