### PR TITLE
fix `querySelector` error

### DIFF
--- a/src/lib/hooks/useGlobalStyles.ts
+++ b/src/lib/hooks/useGlobalStyles.ts
@@ -2,7 +2,7 @@ import React from "react";
 import globalStylesheet, { getClassNames } from "../styles";
 
 function useGlobalStyles(duration: number, hideScrollbars: boolean) {
-  const identifier = React.useMemo(() => Math.random().toString(36).substr(2), []);
+  const identifier = React.useMemo(() => 'drawer' + Math.random().toString(36).substr(2), []);
   const classNames = React.useMemo(() => getClassNames(identifier), [identifier]);
   
   React.useEffect(() => {

--- a/src/lib/hooks/useGlobalStyles.ts
+++ b/src/lib/hooks/useGlobalStyles.ts
@@ -2,7 +2,7 @@ import React from "react";
 import globalStylesheet, { getClassNames } from "../styles";
 
 function useGlobalStyles(duration: number, hideScrollbars: boolean) {
-  const identifier = React.useMemo(() => 'drawer' + Math.random().toString(36).substr(2), []);
+  const identifier = React.useMemo(() => 'rbd' + Math.random().toString(36).substr(2), []);
   const classNames = React.useMemo(() => getClassNames(identifier), [identifier]);
   
   React.useEffect(() => {


### PR DESCRIPTION
If the `identifier` started with a number, the code 
```
document.querySelector(`style[data-react-bottom-drawer='${identifier}']`)
```
 will throw an error in production as the code will be compiled to:
```
var stylesheet = document.querySelector("style[data-react-bottom-drawer=" + identifier + "]");
```

Which in turn will call, (pseudo code)
```
var stylesheet = document.querySelector("style[data-react-bottom-drawer=0bnsia7hf17l"]");
```
which will throw error:
```
Uncaught DOMException: Failed to execute 'querySelector' on 'Document': 'style[data-react-bottom-drawer=0bnsia7hf17l]' is not a valid selector.
```

So the identifier should start with a letter, or we should remove all numbers from the identifier then get a string. The former approach is better, as latter ay come back empty in worst case. Going with `'drawer'` as prefix now. What do you think? @fpellicero 